### PR TITLE
Use autoboxing instead of manual Boolean creation

### DIFF
--- a/aspectj-attic/ajdoc-src/org/aspectj/tools/ajdoc/Access.java
+++ b/aspectj-attic/ajdoc-src/org/aspectj/tools/ajdoc/Access.java
@@ -112,7 +112,7 @@ public class Access {
                     "printNavSummaryLink",
                     new Class[]{ClassDoc.class,
                                 boolean.class},
-                    new Object[]{cd, new Boolean(link)});
+                    new Object[]{cd, link});
     }
     public static void printNavDetailLink(AbstractSubWriter mw,
                                           boolean link) {
@@ -120,7 +120,7 @@ public class Access {
                     mw.del(),
                     "printNavDetailLink",
                     new Class[]{boolean.class},
-                    new Object[]{new Boolean(link)});
+                    new Object[]{link});
     }
     public static void printTags(AbstractSubWriter mw,
                                  ProgramElementDoc member) {

--- a/docs/sandbox/ubc-design-patterns/src/ca/ubc/cs/spl/aspectPatterns/examples/interpreter/aspectj/VariableContext.java
+++ b/docs/sandbox/ubc-design-patterns/src/ca/ubc/cs/spl/aspectPatterns/examples/interpreter/aspectj/VariableContext.java
@@ -66,6 +66,6 @@ public class VariableContext {
 	 */
 	
 	public void assign(VariableExpression varExp, boolean bool) {
-		assignments.put(varExp.getName(), new Boolean(bool));
+		assignments.put(varExp.getName(), bool);
 	}
 }

--- a/docs/sandbox/ubc-design-patterns/src/ca/ubc/cs/spl/aspectPatterns/examples/interpreter/java/VariableContext.java
+++ b/docs/sandbox/ubc-design-patterns/src/ca/ubc/cs/spl/aspectPatterns/examples/interpreter/java/VariableContext.java
@@ -64,6 +64,6 @@ public class VariableContext {
 	 */
 	
 	public void assign(VariableExpression varExp, boolean bool) {
-		assignments.put(varExp.getName(), new Boolean(bool));
+		assignments.put(varExp.getName(), bool);
 	}
 }

--- a/org.aspectj.ajdt.core/src/org/aspectj/ajdt/internal/compiler/lookup/EclipseAnnotationConvertor.java
+++ b/org.aspectj.ajdt.core/src/org/aspectj/ajdt/internal/compiler/lookup/EclipseAnnotationConvertor.java
@@ -159,7 +159,7 @@ public class EclipseAnnotationConvertor {
 				return new SimpleAnnotationValue(ElementValue.PRIMITIVE_INT, new Integer(iConstant.intValue()));
 			} else if (c instanceof BooleanConstant) {
 				BooleanConstant iConstant = (BooleanConstant) c;
-				return new SimpleAnnotationValue(ElementValue.PRIMITIVE_BOOLEAN, new Boolean(iConstant.booleanValue()));
+				return new SimpleAnnotationValue(ElementValue.PRIMITIVE_BOOLEAN, iConstant.booleanValue());
 			} else if (c instanceof StringConstant) {
 				StringConstant sConstant = (StringConstant) c;
 				return new SimpleAnnotationValue(ElementValue.STRING, sConstant.stringValue());

--- a/org.aspectj.ajdt.core/testsrc/AroundAMain.java
+++ b/org.aspectj.ajdt.core/testsrc/AroundAMain.java
@@ -34,7 +34,7 @@ public class AroundAMain extends TestCase {
 			"ajc$perSingletonInstance");
 
 		Reflection.invoke(Class.forName("AroundA"), instance, "ajc$around$AroundA$1$73ebb943", // was $AroundA$46
-					new Integer(10), new Boolean(true), closure);
+					new Integer(10), Boolean.TRUE, closure);
 
 		Reflection.invoke(Class.forName("AroundA"), instance, "ajc$around$AroundA$2$a758212d",  // Was $AroundA$c5
 					"hello there", closure);

--- a/org.aspectj.matcher/src/org/aspectj/weaver/ResolvedTypeMunger.java
+++ b/org.aspectj.matcher/src/org/aspectj/weaver/ResolvedTypeMunger.java
@@ -259,7 +259,7 @@ public abstract class ResolvedTypeMunger {
 		} else {
 			s.writeByte(0);
 			ObjectOutputStream oos = new ObjectOutputStream(s);
-			oos.writeObject(new Boolean(location != null));
+			oos.writeObject(location != null);
 			if (location != null) {
 				oos.writeObject(location.getSourceFile());
 				oos.writeObject(new Integer(location.getLine()));

--- a/org.aspectj.matcher/src/org/aspectj/weaver/SimpleAnnotationValue.java
+++ b/org.aspectj.matcher/src/org/aspectj/weaver/SimpleAnnotationValue.java
@@ -95,7 +95,7 @@ public class SimpleAnnotationValue extends AnnotationValue {
 		case 'S': // short
 			return Short.toString(theShort);
 		case 'Z': // boolean
-			return new Boolean(theBoolean).toString();
+			return Boolean.valueOf(theBoolean).toString();
 		case 's': // String
 			return theString;
 		default:

--- a/org.aspectj.matcher/src/org/aspectj/weaver/patterns/ExactTypePattern.java
+++ b/org.aspectj.matcher/src/org/aspectj/weaver/patterns/ExactTypePattern.java
@@ -234,8 +234,8 @@ public class ExactTypePattern extends TypePattern {
 	public int hashCode() {
 		int result = 17;
 		result = 37 * result + type.hashCode();
-		result = 37 * result + new Boolean(includeSubtypes).hashCode();
-		result = 37 * result + new Boolean(isVarArgs).hashCode();
+		result = 37 * result + Boolean.valueOf(includeSubtypes).hashCode();
+		result = 37 * result + Boolean.valueOf(isVarArgs).hashCode();
 		result = 37 * result + typeParameters.hashCode();
 		result = 37 * result + annotationPattern.hashCode();
 		return result;

--- a/org.aspectj.matcher/src/org/aspectj/weaver/tools/AbstractTrace.java
+++ b/org.aspectj.matcher/src/org/aspectj/weaver/tools/AbstractTrace.java
@@ -52,11 +52,11 @@ public abstract class AbstractTrace implements Trace {
 	}
 
 	public void enter (String methodName, Object thiz, boolean z) {
-		enter(methodName,thiz,new Boolean(z));
+		enter(methodName,thiz, Boolean.valueOf(z));
 	}
 
 	public void exit (String methodName, boolean b) {
-		exit(methodName,new Boolean(b));
+		exit(methodName, Boolean.valueOf(b));
 	}
 
 	public void exit (String methodName, int i) {

--- a/runtime/src/org/aspectj/runtime/internal/Conversions.java
+++ b/runtime/src/org/aspectj/runtime/internal/Conversions.java
@@ -41,7 +41,7 @@ public final class Conversions {
         return new Double(i);
     }
 	public static Object booleanObject(boolean i) {
-        return new Boolean(i);
+        return i;
     }
 	public static Object voidObject() {
         return null;

--- a/testing/src/org/aspectj/testing/util/RunUtils.java
+++ b/testing/src/org/aspectj/testing/util/RunUtils.java
@@ -178,10 +178,10 @@ public class RunUtils {
                 status.getIdentifier(),
                 status.getResult(),
                 numChildren,
-                new Boolean(status.isCompleted()),
+                status.isCompleted(),
                 //status.getParent(),               // costly if parent printing us
                 status.getAbortRequest(),
-                new Boolean(status.started()),
+                status.started(),
                 thrownString,
                 numMessages };
         return org.aspectj.testing.util.LangUtil.debugStr(status.getClass(), LABELS, values);


### PR DESCRIPTION
Doing memory sampling on one of our apps I've found allocations of java.lang.Boolean which is pointless. Instead we can use autoboxing or explicit call to Boolean.valueOf where necessary.