### PR TITLE
URL Cleanup

### DIFF
--- a/lib/ant/LICENSE
+++ b/lib/ant/LICENSE
@@ -1,7 +1,7 @@
 /*
  *                                 Apache License
  *                           Version 2.0, January 2004
- *                        http://www.apache.org/licenses/
+ *                        https://www.apache.org/licenses/
  *
  *   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
  *
@@ -193,7 +193,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/WHATSNEW
+++ b/lib/ant/WHATSNEW
@@ -578,7 +578,7 @@ Changes that could break older environments:
 --------------------------------------------
 
 * License is now Apache Software License 2.0
-  see http://www.apache.org/licenses/ for more information
+  see https://www.apache.org/licenses/ for more information
 
 Fixed bugs:
 -----------

--- a/lib/ant/bin/ant
+++ b/lib/ant/bin/ant
@@ -6,7 +6,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#       http://www.apache.org/licenses/LICENSE-2.0
+#       https://www.apache.org/licenses/LICENSE-2.0
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/bin/antRun
+++ b/lib/ant/bin/antRun
@@ -7,7 +7,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 # 
-#       http://www.apache.org/licenses/LICENSE-2.0
+#       https://www.apache.org/licenses/LICENSE-2.0
 # 
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/bin/antRun.pl
+++ b/lib/ant/bin/antRun.pl
@@ -6,7 +6,7 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/bin/complete-ant-cmd.pl
+++ b/lib/ant/bin/complete-ant-cmd.pl
@@ -6,7 +6,7 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/bin/runant.pl
+++ b/lib/ant/bin/runant.pl
@@ -6,7 +6,7 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/bin/runant.py
+++ b/lib/ant/bin/runant.py
@@ -5,7 +5,7 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/changelog.xsl
+++ b/lib/ant/etc/changelog.xsl
@@ -11,7 +11,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/checkstyle/checkstyle-frames.xsl
+++ b/lib/ant/etc/checkstyle/checkstyle-frames.xsl
@@ -10,7 +10,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/checkstyle/checkstyle-text.xsl
+++ b/lib/ant/etc/checkstyle/checkstyle-text.xsl
@@ -7,7 +7,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/checkstyle/checkstyle-xdoc.xsl
+++ b/lib/ant/etc/checkstyle/checkstyle-xdoc.xsl
@@ -10,7 +10,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/coverage-frames.xsl
+++ b/lib/ant/etc/coverage-frames.xsl
@@ -11,7 +11,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/jdepend-frames.xsl
+++ b/lib/ant/etc/jdepend-frames.xsl
@@ -10,7 +10,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/jdepend.xsl
+++ b/lib/ant/etc/jdepend.xsl
@@ -7,7 +7,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/junit-frames-xalan1.xsl
+++ b/lib/ant/etc/junit-frames-xalan1.xsl
@@ -12,7 +12,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/junit-frames.xsl
+++ b/lib/ant/etc/junit-frames.xsl
@@ -12,7 +12,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/junit-noframes.xsl
+++ b/lib/ant/etc/junit-noframes.xsl
@@ -11,7 +11,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/log.xsl
+++ b/lib/ant/etc/log.xsl
@@ -7,7 +7,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/maudit-frames.xsl
+++ b/lib/ant/etc/maudit-frames.xsl
@@ -11,7 +11,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/mmetrics-frames.xsl
+++ b/lib/ant/etc/mmetrics-frames.xsl
@@ -13,7 +13,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/ant/etc/tagdiff.xsl
+++ b/lib/ant/etc/tagdiff.xsl
@@ -5,7 +5,7 @@
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
    
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
    
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/bugs181/431976/AbstractDependencyInjectionAspect.aj
+++ b/tests/bugs181/431976/AbstractDependencyInjectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 22 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).